### PR TITLE
Add Terraform modules for GCP architecture

### DIFF
--- a/terraform/instances/main.tf
+++ b/terraform/instances/main.tf
@@ -1,0 +1,15 @@
+resource "google_compute_instance" "vm_instance" {
+  count        = 6
+  name         = "vm-instance-${count.index + 1}"
+  machine_type = "n1-standard-1"
+  zone         = element(["us-west1-a", "us-east1-a", "us-east1-a", "us-east1-b"], count.index)
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+  network_interface {
+    network    = google_compute_network.vpc_network.name
+    subnetwork = element(["subnet-1", "subnet-2", "subnet-2", "subnet-3"], count.index)
+  }
+}

--- a/terraform/instances/outputs.tf
+++ b/terraform/instances/outputs.tf
@@ -1,0 +1,3 @@
+output "instance_names" {
+  value = google_compute_instance.vm_instance[*].name
+}

--- a/terraform/instances/variables.tf
+++ b/terraform/instances/variables.tf
@@ -1,0 +1,1 @@
+# No variables needed for instances

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,17 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+module "vpc" {
+  source = "./vpc"
+}
+
+module "subnets" {
+  source = "./subnets"
+}
+
+module "instances" {
+  source = "./instances"
+}
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_network" {
+  value = module.vpc.network_name
+}
+
+output "subnets" {
+  value = module.subnets.subnet_ids
+}
+
+output "instances" {
+  value = module.instances.instance_names
+}

--- a/terraform/subnets/main.tf
+++ b/terraform/subnets/main.tf
@@ -1,0 +1,20 @@
+resource "google_compute_subnetwork" "subnet1" {
+  name          = "subnet-1"
+  ip_cidr_range = "10.240.0.0/24"
+  region        = "us-west1"
+  network       = google_compute_network.vpc_network.name
+}
+
+resource "google_compute_subnetwork" "subnet2" {
+  name          = "subnet-2"
+  ip_cidr_range = "192.168.1.0/24"
+  region        = "us-east1"
+  network       = google_compute_network.vpc_network.name
+}
+
+resource "google_compute_subnetwork" "subnet3" {
+  name          = "subnet-3"
+  ip_cidr_range = "10.2.0.0/16"
+  region        = "us-east1"
+  network       = google_compute_network.vpc_network.name
+}

--- a/terraform/subnets/outputs.tf
+++ b/terraform/subnets/outputs.tf
@@ -1,0 +1,7 @@
+output "subnet_ids" {
+  value = [
+    google_compute_subnetwork.subnet1.id,
+    google_compute_subnetwork.subnet2.id,
+    google_compute_subnetwork.subnet3.id
+  ]
+}

--- a/terraform/subnets/variables.tf
+++ b/terraform/subnets/variables.tf
@@ -1,0 +1,1 @@
+# No variables needed for subnets

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,10 @@
+variable "project_id" {
+  description = "The GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "The GCP region"
+  type        = string
+  default     = "us-west1"
+}

--- a/terraform/vpc/main.tf
+++ b/terraform/vpc/main.tf
@@ -1,0 +1,4 @@
+resource "google_compute_network" "vpc_network" {
+  name                    = "terraform-vpc"
+  auto_create_subnetworks = false
+}

--- a/terraform/vpc/outputs.tf
+++ b/terraform/vpc/outputs.tf
@@ -1,0 +1,3 @@
+output "network_name" {
+  value = google_compute_network.vpc_network.name
+}

--- a/terraform/vpc/variables.tf
+++ b/terraform/vpc/variables.tf
@@ -1,0 +1,1 @@
+# No variables needed for VPC


### PR DESCRIPTION
This PR adds Terraform modules to set up the described GCP architecture:

- `main.tf` for provider and module definitions
- `variables.tf` for input variables
- `outputs.tf` for output variables

Modules added:
- VPC
- Subnets
- Instances